### PR TITLE
Close #4 - 날씨 API 호출에 Retry 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ dependencies {
 	testImplementation group: 'org.springframework.batch', name: 'spring-batch-test', version: '4.3.3' // batch 테스트
 	implementation 'org.springframework.batch:spring-batch-integration'
 	runtimeOnly 'com.h2database:h2'
+	implementation 'org.springframework.retry:spring-retry:1.3.1'
+	implementation 'org.springframework.boot:spring-boot-starter-aop:2.7.2'
+
+
 
 	// queryDSL 설정
 	implementation "com.querydsl:querydsl-jpa"

--- a/src/main/java/com/leehyeonmin34/weather_reminder/WeatherReminderApplication.java
+++ b/src/main/java/com/leehyeonmin34/weather_reminder/WeatherReminderApplication.java
@@ -4,6 +4,7 @@ import org.springframework.batch.core.configuration.annotation.EnableBatchProces
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableBatchProcessing // 배치 애플리케이션을 구동하는데 필요한 설정을 자동으로 등록시켜준다

--- a/src/main/java/com/leehyeonmin34/weather_reminder/domain/weather_info/dto/WeatherApiResponseDto.java
+++ b/src/main/java/com/leehyeonmin34/weather_reminder/domain/weather_info/dto/WeatherApiResponseDto.java
@@ -1,5 +1,8 @@
 package com.leehyeonmin34.weather_reminder.domain.weather_info.dto;
 
+import com.leehyeonmin34.weather_reminder.global.api.exception.OpenApiResponseStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -52,5 +55,6 @@ public class WeatherApiResponseDto {
         private String unit;
         private float value;
     }
+
 
 }

--- a/src/main/java/com/leehyeonmin34/weather_reminder/domain/weather_info/service/WeatherApiService.java
+++ b/src/main/java/com/leehyeonmin34/weather_reminder/domain/weather_info/service/WeatherApiService.java
@@ -8,6 +8,7 @@ import com.leehyeonmin34.weather_reminder.domain.weather_info.model.WeatherDataT
 import com.leehyeonmin34.weather_reminder.domain.weather_info.repository.WeatherInfoRepository;
 import com.leehyeonmin34.weather_reminder.global.api.exception.OpenApiException;
 import com.leehyeonmin34.weather_reminder.global.api.exception.OpenApiResponseStatus;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
@@ -15,6 +16,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -27,6 +29,7 @@ import java.util.stream.Collectors;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class WeatherApiService {
 
     public static String HOST = "http://apis.data.go.kr";
@@ -41,9 +44,9 @@ public class WeatherApiService {
 
     private final RestTemplate restTemplate;
 
-    public WeatherApiService(final RestTemplateBuilder restTemplateBuilder) {
-        this.restTemplate = restTemplateBuilder.build();
-    }
+//    public WeatherApiService(final RestTemplateBuilder restTemplateBuilder) {
+//        this.restTemplate = restTemplateBuilder.build();
+//    }
 
     public List<WeatherInfo> getWeatherInfo(final Region region, final WeatherDataType weatherDataType) {
         final WeatherApiResponseDto dto = getApi(region, weatherDataType);
@@ -105,8 +108,6 @@ public class WeatherApiService {
     public String getUriString(final String url, final Region region, final WeatherDataType weatherDataType){
         return getUri(url, region, weatherDataType).toString();
     }
-
-
 
     private String parseIntoBaseTime(final LocalDateTime lookupTime){
         // 새벽 5시에 배치로 API를 요청한다. 최신 데이터인 전날 21시 데이터를 조회

--- a/src/main/java/com/leehyeonmin34/weather_reminder/global/config/RetryableRestTemplateConfiguration.java
+++ b/src/main/java/com/leehyeonmin34/weather_reminder/global/config/RetryableRestTemplateConfiguration.java
@@ -1,0 +1,51 @@
+package com.leehyeonmin34.weather_reminder.global.config;
+
+import com.leehyeonmin34.weather_reminder.global.api.exception.OpenApiException;
+import com.leehyeonmin34.weather_reminder.global.api.exception.OpenApiResponseStatus;
+import com.leehyeonmin34.weather_reminder.global.common.StandardResponse;
+import com.leehyeonmin34.weather_reminder.global.error.ErrorResponse;
+import com.leehyeonmin34.weather_reminder.global.error.exception.ErrorCode;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@EnableRetry
+@Configuration
+public class RetryableRestTemplateConfiguration {
+
+    @Bean(name = "restTemplate")
+    public RestTemplate retryableRestTemplate() {
+        SimpleClientHttpRequestFactory clientHttpRequestFactory = new SimpleClientHttpRequestFactory();
+        clientHttpRequestFactory.setReadTimeout(2000);
+        clientHttpRequestFactory.setConnectTimeout(500);
+
+        RestTemplate restTemplate = new RestTemplate(clientHttpRequestFactory) {
+            @Override
+            @Retryable(value = RestClientException.class, maxAttempts = 3, backoff = @Backoff(delay = 60000))
+            public <T> ResponseEntity<T> exchange(URI url, HttpMethod method, HttpEntity<?> requestEntity, Class<T> responseType)
+                    throws RestClientException {
+                return super.exchange(url, method, requestEntity, responseType);
+            }
+
+            @Recover
+            public <T> ResponseEntity<T> exchangeRecover(RestClientException e) {
+                throw new OpenApiException(OpenApiResponseStatus.UNKNOWN_ERROR.getCode());
+            }
+        };
+
+        return restTemplate;
+    }
+}

--- a/src/main/java/com/leehyeonmin34/weather_reminder/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/leehyeonmin34/weather_reminder/global/error/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "C006", "Access is Denied"), // Authentication 객체가 필요한 권한을 보유하지 않은 경우 발생
     INVALID_ENUM_CODE(HttpStatus.BAD_REQUEST.value(), "C007", "Invalid Enum Code"),
     UNHANDLED_ENUM_TYPE_AT_SWITCH(HttpStatus.INTERNAL_SERVER_ERROR.value(), "C008", "Unhandler Enum Type at Switch"),
+    EXTERNAL_API_NOT_RESPONSE(HttpStatus.REQUEST_TIMEOUT.value(), "C009", "External Api doesn't response(Timeout"),
 
     // User
     NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED.value(), "U002", "로그인되지 않았습니다."),

--- a/src/test/java/com/leehyeonmin34/weather_reminder/domain/weather_info/service/WeahterApiTest.java
+++ b/src/test/java/com/leehyeonmin34/weather_reminder/domain/weather_info/service/WeahterApiTest.java
@@ -33,7 +33,6 @@ public class WeahterApiTest extends IntegrationTest {
         WeatherApiResponseDto response = weatherApiService.getApi(URL, region, weatherDataType);
 
         // THEN
-        System.out.println(response);
         WeatherApiResponseDtoTest.validateSuccess(response);
     }
 }

--- a/src/test/java/com/leehyeonmin34/weather_reminder/global/batch/load_info/LoadInfoBatchTest.java
+++ b/src/test/java/com/leehyeonmin34/weather_reminder/global/batch/load_info/LoadInfoBatchTest.java
@@ -14,6 +14,8 @@ import com.mysql.cj.jdbc.MysqlDataSource;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ItemProcessor;
@@ -108,9 +110,4 @@ public class LoadInfoBatchTest extends BatchTestSupport{
             .from(QWeatherInfo.weatherInfo)
             .fetchOne()).isEqualTo(savedWeatherInfoPerRequest * requestNum);
     }
-
-
-
-
-
 }


### PR DESCRIPTION
* Retry를 도입
* AOP, Retry 의존성 추가
* 기존 WeatherApiService가  RestTemplate을 내부에서 만들어 쓰던 걸, Bean으로 등록해 외부에서 주입받도록 함
* 모든 재시도의 실패를 의미하는 EXTERNAL_API_NOT_RESPONSE 추가
* 모든 재시도 실패 시나리오 테스트 추가